### PR TITLE
Validating "preconnect" option only when it is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,20 @@ var assert = require('assert')
  * @class
  */
 function HtmlWebpackPreconnectPlugin(options) {
-  assert.equal(options, undefined, 'The ResourceHintWebpackPlugin does not accept any options')
+  assert.equal(options, undefined, 'The HtmlWebpackPreconnectPlugin does not accept any options')
 }
 
 const addPreconnectLinks = function (htmlPluginData, callback) {
-  var origins = htmlPluginData.plugin.options.preconnect;
-  assert.equal(origins instanceof Array, true, new TypeError('origins need array'));
-  origins.forEach(function (origin) {
+  var preconnectedOrigins = htmlPluginData.plugin.options.preconnect;
+
+  // we don't need to do nothing if the HtmlWebpackPlugin instance don't have the preconnect option
+  if (!preconnectedOrigins) {
+    return callback(null, htmlPluginData);
+  }
+
+  assert.equal(preconnectedOrigins instanceof Array, true, new TypeError('preconnect option needs an array'));
+
+  preconnectedOrigins.forEach(function (origin) {
     // webpack config may contain quotos, remove that
     var href = origin.replace(/['"]+/g, '');
     var tag = {

--- a/test/webpack-v4/test.js
+++ b/test/webpack-v4/test.js
@@ -42,4 +42,63 @@ describe('preconnect - webpack 4', function() {
     })
     compiler.outputFileSystem = new MemoryFileSystem()
   })
+
+  it('throws error when preconnect option is not an array', function(done) {
+    const compiler = webpack({
+      entry: path.join(__dirname, "../../example/index.js"),
+      output: {
+        path: path.join(__dirname, "dist"),
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          preconnect: 'foo',
+        }),
+        new HtmlWebpackPreconnectPlugin(),
+      ],
+    }, function (err, result) {
+      assert.equal(result.compilation.errors.some(error => error.includes('preconnect option needs an array')), true);
+      done();
+    })
+
+    compiler.outputFileSystem = new MemoryFileSystem();
+  })
+
+  it('ignores templates that does not have the "preconnect" option', function (done) {
+    const compiler = webpack({
+      entry: path.join(__dirname, "../../example/index.js"),
+      output: {
+        path: path.join(__dirname, "dist"),
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          filename: "index.html",
+          preconnect: ["https://fonts.gstatic.com"],
+        }),
+        new HtmlWebpackPlugin({
+          filename: "no-preconnect.html"
+        }),
+        new HtmlWebpackPreconnectPlugin(),
+      ],
+    }, function (err, result) {
+      if (err) {
+        done(err);
+        return;
+      }
+      if (result.compilation.errors && result.compilation.errors.length) {
+        done(result.compilation.errors);
+        return;
+      }
+
+      const indexHtml = result.compilation.assets["index.html"].source();
+      const noPreconnectHtml = result.compilation.assets["no-preconnect.html"].source();
+      assert.equal(typeof indexHtml, "string");
+      assert.equal(typeof noPreconnectHtml, "string");
+      assert.ok(indexHtml.includes('<link rel="preconnect" href="https://fonts.gstatic.com"'))
+      assert.ok(!noPreconnectHtml.includes('<link rel="preconnect" href="https://fonts.gstatic.com"'))
+
+      done();
+    });
+
+    compiler.outputFileSystem = new MemoryFileSystem();
+  });
 })


### PR DESCRIPTION
Recently i came down to the case where i need to add the preconnect links in one of my `html-webpack-plugin` templates but not in the others, and the plugin was throwing an error `TypeError: origins need array`.

I've made a change to the plugin hook to only validate the preconnect option type when it is actually present in the options, so we can do something like this in our webpack config:

```js
{
  plugins: [
    new HtmlWebpackPlugin({
      filename: "index.html",
      preconnect: ["https://fonts.gstatic.com"],
    }),
    new HtmlWebpackPlugin({
      filename: "no-preconnect.html"
    }),
  ]
}
```

I have also fixed the error message to match the option name: `preconnect option needs an array`.

Let me know if that looks good for you :) 
